### PR TITLE
fix some weird Template haskell bug by reordering one line of code...

### DIFF
--- a/hanoi.cabal
+++ b/hanoi.cabal
@@ -26,7 +26,7 @@ library
     -Wall -Wno-name-shadowing -fno-ignore-asserts
 
   build-depends:
-      base >=4.7 && <4.15
+      base >=4.7 && <4.18
     , containers >= 0.6.0.1 && <0.7
     , finite >= 1.4.1
     , parsec

--- a/src/lib/HOA/Format.hs
+++ b/src/lib/HOA/Format.hs
@@ -1,19 +1,20 @@
 -----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-----------------------------------------------------------------------------
+
 -- |
 -- Module      :  HOA.Format
 -- Maintainer  :  Philippe Heim
 --
 -- The internal representation of an HOA
---
------------------------------------------------------------------------------
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TemplateHaskell       #-}
-
------------------------------------------------------------------------------
 module HOA.Format where
 
 -----------------------------------------------------------------------------
@@ -24,20 +25,24 @@ import GHC.Generics (Generic)
 import HOA.Formula (Formula)
 
 -----------------------------------------------------------------------------
+
 -- | The type of a state, generated using the Finite library
 newInstance "State"
 
 -----------------------------------------------------------------------------
+
 -- | The type of an atomic proposition, generated using the Finite library
 newInstance "AP"
 
 -----------------------------------------------------------------------------
+
 -- | The type of an acceptance set, generated using the Finite library
 newInstance "AcceptanceSet"
 
 type AcceptanceSets = Set AcceptanceSet
 
 -----------------------------------------------------------------------------
+
 -- | The different properties of a HOA
 -- Remark: The properties do not contain implicit-labels, explicit-labels,
 -- as in the internal format all labels are explicit
@@ -62,6 +67,7 @@ data HOAProperty
   deriving (Eq, Ord, Show)
 
 -----------------------------------------------------------------------------
+
 -- | All possible HOA acceptance names with the respective parameters
 data HOAAcceptanceName
   = Buchi
@@ -78,7 +84,9 @@ data HOAAcceptanceName
   | All
   | None
   deriving (Show)
+
 -----------------------------------------------------------------------------
+
 -- | The definition of an acceptance condition, which is a propositional formula
 -- over acceptance sets that are visited finitely of infinitely often
 data AcceptanceType
@@ -88,62 +96,66 @@ data AcceptanceType
 
 type AcceptanceCondition = Formula AcceptanceType
 
-instance Finite HOA AcceptanceType
-
 instance Finite HOA Bool
 
 -----------------------------------------------------------------------------
+
 -- | The definition of a label, which is a propositional formula over
 -- atomic propositions
 type Label = Formula AP
 
 -----------------------------------------------------------------------------
+
 -- | The internal presentation of an HOA, note that alias and implicit labels
 -- are not represented anymore
-data HOA =
-  HOA
-    { -- | Number of states (set can be computed via the type)
-      size :: Int
-    , -- | Set of initial states (singletons) or conjuncts of initial states
-      -- for alternating automata, each list forms a conjunct
-      initialStates :: Set [State]
-    , -- | Number of atomic propositions (set can be computed via the type)
-      atomicPropositions :: Int
-    , -- | Name of the atomic proposition
-      atomicPropositionName :: AP -> String
-    , -- | Controllable APs, typically outputs (Syntcomp Extension)
-      controllableAPs :: Set AP
-    , -- | Acceptance name
-      acceptanceName :: Maybe HOAAcceptanceName
-    , -- | Number of acceptance sets (the sets can be computed via the type)
-      acceptanceSets :: Int
-    , -- | Acceptance condition
-      acceptance :: AcceptanceCondition
-    , -- | Tool name, parameters
-      tool :: Maybe (String, Maybe String)
-    , -- | Automaton name
-      name :: Maybe String
-    , -- | Properties
-      properties :: Set HOAProperty
-    , -- | Set of edges for each state, an edge consists of target state
-      -- (-conjunct) a optional label and an optional set of acceptance sets
-      edges :: State -> Set ([State], Maybe Label, Maybe AcceptanceSets)
-    , -- | For each state a possible label
-      stateLabel :: State -> Maybe Label
-    , -- | For each state a possible set of acceptance sets
-      stateAcceptance :: State -> Maybe AcceptanceSets
-    , -- | Name of a state
-      stateName :: State -> Maybe String
-    }
+data HOA = HOA
+  { -- | Number of states (set can be computed via the type)
+    size :: Int,
+    -- | Set of initial states (singletons) or conjuncts of initial states
+    -- for alternating automata, each list forms a conjunct
+    initialStates :: Set [State],
+    -- | Number of atomic propositions (set can be computed via the type)
+    atomicPropositions :: Int,
+    -- | Name of the atomic proposition
+    atomicPropositionName :: AP -> String,
+    -- | Controllable APs, typically outputs (Syntcomp Extension)
+    controllableAPs :: Set AP,
+    -- | Acceptance name
+    acceptanceName :: Maybe HOAAcceptanceName,
+    -- | Number of acceptance sets (the sets can be computed via the type)
+    acceptanceSets :: Int,
+    -- | Acceptance condition
+    acceptance :: AcceptanceCondition,
+    -- | Tool name, parameters
+    tool :: Maybe (String, Maybe String),
+    -- | Automaton name
+    name :: Maybe String,
+    -- | Properties
+    properties :: Set HOAProperty,
+    -- | Set of edges for each state, an edge consists of target state
+    -- (-conjunct) a optional label and an optional set of acceptance sets
+    edges :: State -> Set ([State], Maybe Label, Maybe AcceptanceSets),
+    -- | For each state a possible label
+    stateLabel :: State -> Maybe Label,
+    -- | For each state a possible set of acceptance sets
+    stateAcceptance :: State -> Maybe AcceptanceSets,
+    -- | Name of a state
+    stateName :: State -> Maybe String
+  }
 
 -----------------------------------------------------------------------------
+
 -- | The instantiation of the State type
 baseInstance [t|HOA|] [|size|] "State"
 
 -----------------------------------------------------------------------------
+
 -- | The instantiation of the atomic proposition type
 baseInstance [t|HOA|] [|atomicPropositions|] "AP"
 
 -----------------------------------------------------------------------------
+
 -- | The instantiation of the acceptance set type
 baseInstance [t|HOA|] [|acceptanceSets|] "AcceptanceSet"
+
+instance Finite HOA AcceptanceType

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.0
+resolver: lts-21.15
 packages:
 - .
 extra-deps:
@@ -6,3 +6,4 @@ extra-deps:
   commit: 8a37de506728ebbcfab05ea8ac3ff50aa34a2c9d
 - git: https://github.com/reactive-systems/automata-tools-wrappers.git
   commit: fdeefb53c57600a5217a82015886f7abbf65263d
+allow-newer: true


### PR DESCRIPTION
I honestly have no idea, but I wanted this to work on GHC 9.4.7 and I was getting the below error. Reordering one line of template haskell somehow fixed it. Probably there is a better fix but I don't understand this code.

```

/home/msantolu/Github/hanoi/src/lib/HOA/Format.hs:91:10: error:
    • Could not deduce (Finite HOA AcceptanceSet)
        arising from a use of ‘finite-1.4.1.2:Finite.Class.$dmelements’
      from the context: FiniteBounds HOA
        bound by the type signature for:
                   elements :: FiniteBounds HOA => T AcceptanceType -> Int
        at src/lib/HOA/Format.hs:91:10-34
    • In the expression:
        finite-1.4.1.2:Finite.Class.$dmelements @(HOA) @(AcceptanceType)
      In an equation for ‘elements’:
          elements
            = finite-1.4.1.2:Finite.Class.$dmelements @(HOA) @(AcceptanceType)
      In the instance declaration for ‘Finite HOA AcceptanceType’
   |
91 | instance Finite HOA AcceptanceType
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^

/home/msantolu/Github/hanoi/src/lib/HOA/Format.hs:91:10: error:
    • Could not deduce (Finite HOA AcceptanceSet)
        arising from a use of ‘finite-1.4.1.2:Finite.Class.$dmindex’
      from the context: FiniteBounds HOA
        bound by the type signature for:
                   index :: FiniteBounds HOA => AcceptanceType -> Int
        at src/lib/HOA/Format.hs:91:10-34
    • In the expression:
        finite-1.4.1.2:Finite.Class.$dmindex @(HOA) @(AcceptanceType)
      In an equation for ‘index’:
          index
            = finite-1.4.1.2:Finite.Class.$dmindex @(HOA) @(AcceptanceType)
      In the instance declaration for ‘Finite HOA AcceptanceType’
   |
91 | instance Finite HOA AcceptanceType
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^

/home/msantolu/Github/hanoi/src/lib/HOA/Format.hs:91:10: error:
    • Could not deduce (Finite HOA AcceptanceSet)
        arising from a use of ‘finite-1.4.1.2:Finite.Class.$dmvalue’
      from the context: FiniteBounds HOA
        bound by the type signature for:
                   value :: FiniteBounds HOA => Int -> AcceptanceType
        at src/lib/HOA/Format.hs:91:10-34
    • In the expression:
        finite-1.4.1.2:Finite.Class.$dmvalue @(HOA) @(AcceptanceType)
      In an equation for ‘value’:
          value
            = finite-1.4.1.2:Finite.Class.$dmvalue @(HOA) @(AcceptanceType)
      In the instance declaration for ‘Finite HOA AcceptanceType’
   |
91 | instance Finite HOA AcceptanceType
```